### PR TITLE
fix(zones/shared): ensure safe removal of zones from entering and exiting lists

### DIFF
--- a/imports/zones/shared.lua
+++ b/imports/zones/shared.lua
@@ -122,8 +122,15 @@ local function removeZone(zone)
 
     insideZones[zone.id] = nil
 
-    table.remove(exitingZones, exitingZones:indexOf(zone))
-    table.remove(enteringZones, enteringZones:indexOf(zone))
+    local exitingIndex = exitingZones:indexOf(zone)
+    if exitingIndex then
+        table.remove(exitingZones, exitingIndex)
+    end
+
+    local enteringIndex = enteringZones:indexOf(zone)
+    if enteringIndex then
+        table.remove(enteringZones, enteringIndex)
+    end
 end
 
 CreateThread(function()


### PR DESCRIPTION
## Description:
This PR addresses edge case issues with zone handling when entering and exiting multiple zones simultaneously. The changes focus on ensuring proper index validation before attempting to remove entries from the zone arrays.

## Changes:
    Added validation for exitingIndex before attempting to remove zones from the exitingZones array
    Added validation for enteringIndex before attempting to remove zones from the enteringZones array
    Fixed potential errors when a zone is being removed while it's being processed for entering or exiting

## Impact:
This fix resolves issues that could occur in scenarios such as:

    Entering or exiting multiple zones at the same time
    Removing a zone while it's being processed for entering/exiting events
    Edge cases where the zone's index might not exist in the respective arrays

These improvements ensure more stable behavior of the zone system, especially in complex environments with many overlapping zones or when zones are being dynamically created and destroyed.

totally not ai generated description
