### PR TITLE
chore(package/interface): add label to progressCircle

### DIFF
--- a/package/client/resource/interface/progress.ts
+++ b/package/client/resource/interface/progress.ts
@@ -12,6 +12,7 @@ interface PropProps {
 }
 
 interface ProgressProps {
+  label?: string; 
   duration: number;
   position?: 'middle' | 'bottom';
   useWhileDead?: boolean;


### PR DESCRIPTION
Currently label is not provided when doing progressCircle which causes a type error when using typescript.

This PR aims to add label into the progressCircle types.