### PR TITLE
ci(create-release): bump version before running build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,19 +34,6 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
 
 
-      - name: Install package dependencies
-        run: bun install --frozen-lockfile
-        working-directory: package
-
-      - name: Install web dependencies
-        run: bun install --frozen-lockfile
-        working-directory: web
-
-      - name: Run web build script
-        run: bun run build
-        working-directory: web
-
-
       - name: Bump package version
         run: bun run .github/actions/bump-package-version.js
         env:
@@ -64,6 +51,19 @@ jobs:
           push: true
           default_author: github_actions
           message: 'chore: bump version to ${{ github.ref_name }}'
+
+
+      - name: Install package dependencies
+        run: bun install --frozen-lockfile
+        working-directory: package
+
+      - name: Install web dependencies
+        run: bun install --frozen-lockfile
+        working-directory: web
+
+      - name: Run web build script
+        run: bun run build
+        working-directory: web
 
 
       - name: Bundle files


### PR DESCRIPTION
Fixes an issue where new releases still had old versions in their `fxmanifest.lua`/`package.json`.