### PR TITLE
feat(imports/getClosestPlayer): Implement ignorePlayerId

### DIFF
--- a/imports/getClosestPlayer/server.lua
+++ b/imports/getClosestPlayer/server.lua
@@ -8,25 +8,29 @@
 
 ---@param coords vector3 The coords to check from.
 ---@param maxDistance? number The max distance to check.
+---@param ignorePlayerId? number|false The player server ID to ignore.
 ---@return number? playerId
 ---@return number? playerPed
 ---@return vector3? playerCoords
-function lib.getClosestPlayer(coords, maxDistance)
+function lib.getClosestPlayer(coords, maxDistance, ignorePlayerId)
     local players = GetActivePlayers()
     local closestId, closestPed, closestCoords
     maxDistance = maxDistance or 2.0
 
     for i = 1, #players do
         local playerId = players[i]
-        local playerPed = GetPlayerPed(playerId)
-        local playerCoords = GetEntityCoords(playerPed)
-        local distance = #(coords - playerCoords)
 
-        if distance < maxDistance then
-            maxDistance = distance
-            closestId = playerId
-            closestPed = playerPed
-            closestCoords = playerCoords
+        if not ignorePlayerId or playerId ~= ignorePlayerId then
+            local playerPed = GetPlayerPed(playerId)
+            local playerCoords = GetEntityCoords(playerPed)
+            local distance = #(coords - playerCoords)
+
+            if distance < maxDistance then
+                maxDistance = distance
+                closestId = playerId
+                closestPed = playerPed
+                closestCoords = playerCoords
+            end
         end
     end
 


### PR DESCRIPTION
Adds an optional `ignorePlayerId` argument to `lib.getClosestPlayer` (server-side).
This lets you skip a specific player when checking for the closest one.
Useful if you want to ignore the player who triggered the check.

[Docs PR](https://github.com/CommunityOx/docs/pull/7)