### PR TITLE
Non-RGB secondary colour gets reset if primary colour is RGB and vise-versa

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -349,7 +349,7 @@ function lib.setVehicleProperties(vehicle, props, fixVehicle)
     if props.color1 then
         if type(props.color1) == 'number' then
             ClearVehicleCustomPrimaryColour(vehicle)
-            SetVehicleColours(vehicle, props.color1 --[[@as number]], colorSecondary --[[@as number]])
+            SetVehicleColours(vehicle, props.color1 --[[@as number]], type(colorSecondary) == "number" and colorSecondary or 0 --[[@as number]])
         else
             if props.paintType1 then SetVehicleModColor_1(vehicle, props.paintType1, 0, props.pearlescentColor or 0) end
 
@@ -360,7 +360,9 @@ function lib.setVehicleProperties(vehicle, props, fixVehicle)
     if props.color2 then
         if type(props.color2) == 'number' then
             ClearVehicleCustomSecondaryColour(vehicle)
-            SetVehicleColours(vehicle, props.color1 or colorPrimary --[[@as number]], props.color2 --[[@as number]])
+
+            local primaryColour = props.color1 or colorPrimary
+            SetVehicleColours(vehicle, type(primaryColour) == "number" and primaryColour or 0 --[[@as number]], props.color2 --[[@as number]])
         else
             if props.paintType2 then SetVehicleModColor_2(vehicle, props.paintType2, 0) end
 


### PR DESCRIPTION
I'll try to explain this with an example and a reproduction:

- You have an RGB primary colour set (non number; utilising `SetVehicleCustomPrimaryColour`)
- You have a standard secondary colour set (using a colour ID, utilising `SetVehicleColours`)
- When trying to set the **secondary** colour with `SetVehicleColours`, we have to pass `props.color1` as the second arg, which in this case is a table
- While this doesn't error out, it makes the native call fail and the secondary colour is never set, and in my testing actually causes it to reset to `0`

Hope this makes sense!