### PR TITLE
fix(client/interface): add missing warning notify type in npm package

### DIFF
--- a/package/client/resource/interface/notify.ts
+++ b/package/client/resource/interface/notify.ts
@@ -10,7 +10,7 @@ type NotificationPosition =
   | 'bottom-left'
   | 'center-right'
   | 'center-left';
-type NotificationType = 'inform' | 'error' | 'success';
+type NotificationType = 'inform' | 'error' | 'success' | 'warning';
 type IconAnimation = 'spin' | 'spinPulse' | 'spinReverse' | 'pulse' | 'beat' | 'fade' | 'beatFade' | 'bounce' | 'shake';
 
 interface NotifyProps {


### PR DESCRIPTION
This PR fixes an oversight related to notification types in the npm package. Currently, the `warning` type is missing, but the modified code adds it into the used type for the `notify` function.