### PR TITLE
Use @nativewrappers/fivem instead of @nativewrappers/client

### DIFF
--- a/package/bun.lock
+++ b/package/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@communityox/ox_lib",
       "dependencies": {
-        "@nativewrappers/client": "^1.7.33",
+        "@nativewrappers/fivem": "^0.0.103",
         "csstype": "^3.1.3",
         "fast-printf": "^1.6.9",
         "typescript": "^5.4.2",
@@ -97,7 +97,7 @@
 
     "@mantine/utils": ["@mantine/utils@6.0.22", "", { "peerDependencies": { "react": ">=16.8.0" } }, "sha512-RSKlNZvxhMCkOFZ6slbYvZYbWjHUM+PxDQnupIOxIdsTZQQjx/BFfrfJ7kQFOP+g7MtpOds8weAetEs5obwMOQ=="],
 
-    "@nativewrappers/client": ["@nativewrappers/client@1.7.33", "", {}, "sha512-phuBBGdDPxZiZyw5CaFs1XWfvllnEtwATMdLaNucwMofVg/O/FjlP1bTUq4SOm4qhSZ4Zdo351ijHzBSIbZs6g=="],
+    "@nativewrappers/fivem": ["@nativewrappers/fivem@0.0.103", "", {}, "sha512-x0W00Mx9ZN/rTS9XZc5Kf1hjahqRmlo9sPiuJP4kCYeQG4LDJyglXCsHcfNfygGq6WEblG1W2FLgm4MGDn/wHA=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" } }, "sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA=="],
 

--- a/package/client/resource/points/index.ts
+++ b/package/client/resource/points/index.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from '@nativewrappers/client';
+import { Vector3 } from '@nativewrappers/fivem';
 import { cache } from '../cache';
 
 let points: Point[] = [];

--- a/package/package.json
+++ b/package/package.json
@@ -28,7 +28,7 @@
   },
   "license": "LGPL-3.0",
   "dependencies": {
-    "@nativewrappers/client": "^1.7.33",
+    "@nativewrappers/fivem": "^0.0.103",
     "csstype": "^3.1.3",
     "fast-printf": "^1.6.9",
     "typescript": "^5.4.2"

--- a/package/shared/resource/getNearbyVehicles/index.ts
+++ b/package/shared/resource/getNearbyVehicles/index.ts
@@ -1,6 +1,6 @@
 import { cache } from '../cache/index';
 import { context } from '../../index';
-import { Vector3 } from "@nativewrappers/client";
+import { Vector3 } from "@nativewrappers/fivem";
 
 interface NearbyVehicle {
     vehicle: number;


### PR DESCRIPTION
This PR switches from using @nativewrappers/**client** to @nativewrappers/**fivem** .

The "client" package has not been updated in about 3 years and appears to be no longer maintained.
https://www.npmjs.com/package/@nativewrappers/client

Instead, I propose using @nativewrappers/fivem, which has been under development until relatively recently.
https://www.npmjs.com/package/@nativewrappers/fivem