### PR TITLE
fix(client/interface): fix longer progess bars fails because of NUI and GetGameTimer() desync

### DIFF
--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -150,7 +150,8 @@ local function startProgress(data)
     end
 
     playerState.invBusy = false
-    local duration = progress ~= false and GetGameTimer() - startTime + 100 -- give slight leeway
+    local timeOffset = (data.duration / 1000) * 20 -- try to match NUI duration with the game timer as quick fix
+    local duration = progress ~= false and (GetGameTimer() - startTime + timeOffset) or 0
 
     if progress == false or duration <= data.duration then
         SendNUIMessage({ action = 'progressCancel' })


### PR DESCRIPTION
Steps to reproduce this bug:
- Use a **lib.progressbar** longer than **60-90s** and will guarantee to fail most of the time
I found this while testing my crafting system which uses a very long progressbar (300 seconds) and most of the time was failing. I initially though it was my crafting system but digging deeply this part was failing in oxlib:

```lua
if progress == false or duration <= data.duration then
```

I believe the issue is a time desync between NUI and GetGameTimer(), initially Linden/Luke gave a +100ms slight compensation which was only good for short time "errors", not for longer ones.
This might be a temporary solution only. A better one to compensate the error fully might be better.