### PR TITLE
Handle ped value 0 during player transition

### DIFF
--- a/resource/cache/client.lua
+++ b/resource/cache/client.lua
@@ -46,6 +46,7 @@ CreateThread(function()
 				if not cache.seat or GetPedInVehicleSeat(vehicle, cache.seat) ~= ped then
 					for i = -1, GetVehicleMaxNumberOfPassengers(vehicle) - 1 do
 						if GetPedInVehicleSeat(vehicle, i) == ped then
+							cache:set('seat', i)
 							break
 						end
 					end


### PR DESCRIPTION
Added a check to skip cache updates when PlayerPedId() returns 0, which can occur during ped transitions. This prevents invalid cache states and potential errors when the player's ped is temporarily unavailable.