### PR TITLE
feat(web/dialog/textarea): add min and max length

### DIFF
--- a/web/src/features/dialog/components/fields/textarea.tsx
+++ b/web/src/features/dialog/components/fields/textarea.tsx
@@ -24,6 +24,8 @@ const TextareaField: React.FC<Props> = (props) => {
       autosize={props.row.autosize}
       minRows={props.row.min}
       maxRows={props.row.max}
+      minLength={props.row.minLength}
+      maxLength={props.row.maxLength}
     />
   );
 };

--- a/web/src/typings/dialog.ts
+++ b/web/src/typings/dialog.ts
@@ -76,4 +76,6 @@ export interface ITextarea extends BaseField<'textarea', string> {
   autosize?: boolean;
   min?: number;
   max?: number;
+  minLength?: number;
+  maxLength?: number;
 }


### PR DESCRIPTION
This PR adds `minLength` and `maxLength` options to `textarea` input type.
I will make docs PR once this gets merged.