### PR TITLE
fix(interface/input): add min and max length props to input type

### DIFF
--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -30,6 +30,8 @@ local input
 ---@field searchable? boolean
 ---@field description? string
 ---@field maxSelectedValues? number
+---@field minLength? number
+---@field maxLength? number
 
 ---@class InputDialogOptionsProps
 ---@field allowCancel? boolean


### PR DESCRIPTION
Forgot to add this in https://github.com/CommunityOx/ox_lib/pull/30.