### PR TITLE
feat(web): add size to input dialog options

### DIFF
--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -35,6 +35,7 @@ local input
 
 ---@class InputDialogOptionsProps
 ---@field allowCancel? boolean
+---@field size? 'xs' | 'sm' | 'md' | 'lg' | 'xl'
 
 ---@param heading string
 ---@param rows string[] | InputDialogRowProps[]

--- a/web/src/features/dialog/InputDialog.tsx
+++ b/web/src/features/dialog/InputDialog.tsx
@@ -103,7 +103,7 @@ const InputDialog: React.FC = () => {
         centered
         closeOnEscape={fields.options?.allowCancel !== false}
         closeOnClickOutside={false}
-        size="xs"
+        size={fields.options?.size || 'xs'}
         styles={{ title: { textAlign: 'center', width: '100%', fontSize: 18 } }}
         title={fields.heading}
         withCloseButton={false}

--- a/web/src/typings/dialog.ts
+++ b/web/src/typings/dialog.ts
@@ -5,6 +5,7 @@ export interface InputProps {
   rows: Array<IInput | ICheckbox | ISelect | INumber | ISlider | IColorInput | IDateInput | ITextarea | ITimeInput>;
   options?: {
     allowCancel?: boolean;
+    size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   };
 }
 


### PR DESCRIPTION
This PR aims to add a size parameter to the ox_lib input dialogs.

Example:
```lua

lib.inputDialog('TEST DIALOG',{
    { type = 'input', label = 'Input 1', placeholder = 'Type something here...' },
}, {
    size = 'md'
})
```