### PR TITLE
fix(web/notifications): bottom center position

### DIFF
--- a/web/src/features/dev/debug/notification.ts
+++ b/web/src/features/dev/debug/notification.ts
@@ -26,6 +26,7 @@ export const debugCustomNotification = () => {
         title: 'Error',
         description: 'Notification description',
         type: 'error',
+        position: "bottom"
       },
     },
   ]);

--- a/web/src/features/notifications/NotificationWrapper.tsx
+++ b/web/src/features/notifications/NotificationWrapper.tsx
@@ -61,7 +61,7 @@ const getAnimation = (visible: boolean, position: string) => {
       animation = { from: 'X(0px)', to: 'X(-100%)' };
     } else if (position === 'top-center') {
       animation = { from: 'Y(0px)', to: 'Y(-100%)' };
-    } else if (position === 'bottom') {
+    } else if (position === 'bottom-center') {
       animation = { from: 'Y(0px)', to: 'Y(100%)' };
     } else {
       animation = { from: 'X(0px)', to: 'X(100%)' };


### PR DESCRIPTION
some old backwards compat commit broke bottom center exit anim (would go left instead of back bottom)