### PR TITLE
feat(web/notifications): ignore icon if set to false

### DIFF
--- a/package/client/resource/interface/notify.ts
+++ b/package/client/resource/interface/notify.ts
@@ -22,7 +22,7 @@ interface NotifyProps {
   position?: NotificationPosition;
   type?: NotificationType;
   style?: Sx;
-  icon?: IconName | [IconPrefix, IconName];
+  icon?: IconName | [IconPrefix, IconName] | false;
   iconColor?: string;
   iconAnimation?: IconAnimation;
   alignIcon?: 'top' | 'center';

--- a/web/src/features/notifications/NotificationWrapper.tsx
+++ b/web/src/features/notifications/NotificationWrapper.tsx
@@ -103,7 +103,7 @@ const Notifications: React.FC = () => {
         break;
     }
 
-    if (!data.icon) {
+    if (data.icon == undefined) {
       switch (data.type) {
         case 'error':
           data.icon = 'circle-xmark';

--- a/web/src/typings/notifications.ts
+++ b/web/src/typings/notifications.ts
@@ -9,7 +9,7 @@ export interface NotificationProps {
   title?: string;
   duration?: number;
   showDuration?: boolean;
-  icon?: IconProp;
+  icon?: IconProp | false;
   iconColor?: string;
   iconAnimation?: IconAnimation;
   position?: ToastPosition | 'top' | 'bottom';


### PR DESCRIPTION
This PR introduces a new feature for notifications: if the icon prop is explicitly set to false, the icon will not be rendered. If the icon prop is not provided, it will continue to fall back to the default icon.

This allows for more flexible and sleek custom notification styles, especially since we already support inline styles with React.

<img width="336" height="142" alt="image" src="https://github.com/user-attachments/assets/c6d23ad4-e48b-42b2-ae01-d4fd1e61b8b9" />
