### PR TITLE
fix(points): grid inconsistencies

### DIFF
--- a/imports/points/client.lua
+++ b/imports/points/client.lua
@@ -39,10 +39,14 @@ local function removePoint(self)
     points[self.id] = nil
 end
 
+local function hasRemovePoint(entry)
+    return entry.remove == removePoint
+end
+
 CreateThread(function()
     while true do
         local coords = GetEntityCoords(cache.ped)
-        local newPoints = lib.grid.getNearbyEntries(coords, function(entry) return entry.remove == removePoint end) --[[@as CPoint[] ]]
+        local newPoints = lib.grid.getNearbyEntries(coords, hasRemovePoint) --[[@as CPoint[] ]]
         local cellX, cellY = lib.grid.getCellPosition(coords)
         cache.coords = coords
         closestPoint = nil

--- a/imports/points/client.lua
+++ b/imports/points/client.lua
@@ -93,9 +93,11 @@ CreateThread(function()
                 nearbyCount += 1
                 nearbyPoints[nearbyCount] = point
 
-                if point.onEnter and not point.inside then
+                if not point.inside then
                     point.inside = true
-                    point:onEnter()
+                    if point.onEnter then
+                        point:onEnter()
+                    end
                 end
             elseif point.currentDistance then
                 if point.onExit then point:onExit() end


### PR DESCRIPTION
- Fix memory constantly going up when having any points.
  Currently, the points thread creates a new filter function every loop iteration and passes it to `lib.grid.getNearbyEntries`, which would break caching, as the filter function would be different every iteration.
  This PR fixes this by creating a local function, and passing it instead, meaning it wouldn't be created over and over, and it would be properly cached.

- Fix `onExit` not firing when both exiting a point and moving grid cells in the same loop iteration, when `onEnter` isn't set.
  When moving grid cells, the points thread uses `point.inside` to check whether to run `onExit`. However, `point.inside` is only set when `onEnter` is defined.
  This PR fixes this by setting `point.inside` even when `onEnter` isn't defined.

Fixes #20.