### PR TITLE
Pull Request: Add Switch Statement Utility

### DIFF
--- a/imports/switch/shared.lua
+++ b/imports/switch/shared.lua
@@ -1,0 +1,110 @@
+--[[
+    https://github.com/communityox/ox_lib
+
+    This file is licensed under LGPL-3.0 or higher <https://www.gnu.org/licenses/lgpl-3.0.en.html>
+
+    Copyright © 2025 KodeRed <https://github.com/Kode-Red>
+]]
+
+--- @alias SwitchMatch any|fun(val:any):boolean|"default"|any[]
+--- @alias BreakFn     fun():nil
+--- @class SwitchCase
+--- @field match  SwitchMatch
+--- @field action fun(breakFn:BreakFn, ...:any):any
+--- @alias SwitchCases SwitchCase[]
+
+local _cache = setmetatable({}, { __mode = "k" })
+local t_unpack = table.unpack
+
+--- compile once per cases to a fast dispatcher (kept local; not exported)
+--- @param cases SwitchCases
+--- @return fun(value:any, fallthrough:boolean|nil, ...:any):any
+local function compile(cases)
+    local map, preds, defaultIndex = {}, {}, nil
+    local n = #cases
+
+    for i = 1, n do
+        local m = cases[i].match
+        local mt = type(m)
+        if m == "default" then
+            defaultIndex = i
+        elseif mt == "function" then
+            preds[#preds + 1] = i
+        elseif mt == "table" then
+            for j = 1, #m do
+                local v = m[j]
+                if map[v] == nil then map[v] = i end
+            end
+        else
+            if map[m] == nil then map[m] = i end
+        end
+    end
+
+    return function(value, fallthrough, ...)
+        local stop, res
+        local function breakFn() stop = true end
+
+        local i = map[value]
+        if i == nil then
+            for k = 1, #preds do
+                local pi = preds[k]
+                if cases[pi].match(value) then
+                    i = pi; break
+                end
+            end
+            if i == nil then i = defaultIndex end
+        end
+        if i == nil then return nil end
+
+        if fallthrough then
+            while i <= n do
+                res = cases[i].action(breakFn, ...)
+                if stop then break end
+                i = i + 1
+            end
+            return res
+        else
+            return cases[i].action(breakFn, ...)
+        end
+    end
+end
+
+--- Switch API (value first, cases third).
+--- Call as:
+---   lib.switch(value, fallthrough, cases, ...)
+---   lib.switch({ value, ... }, fallthrough, cases)
+--- @generic R
+--- @param valueOrArgs any|any[]          -- single value OR { value, arg1, arg2, ... }
+--- @param fallthrough boolean|nil         -- true = allow fallthrough; false/nil = stop at first
+--- @param cases SwitchCases
+--- @param ... any
+--- @return R|any
+function lib.switch(valueOrArgs, fallthrough, cases, ...)
+    local dispatch = _cache[cases]
+    if not dispatch then
+        dispatch = compile(cases)
+        _cache[cases] = dispatch
+    end
+
+    if type(valueOrArgs) == "table" then
+        local value = valueOrArgs[1]
+        local argc = #valueOrArgs
+        if argc > 1 then
+            local packed, p = {}, 0
+            for i = 2, argc do
+                p = p + 1; packed[p] = valueOrArgs[i]
+            end
+            local extra = { ... }
+            for i = 1, #extra do
+                p = p + 1; packed[p] = extra[i]
+            end
+            return dispatch(value, fallthrough, t_unpack(packed))
+        else
+            return dispatch(value, fallthrough, ...)
+        end
+    else
+        return dispatch(valueOrArgs, fallthrough, ...)
+    end
+end
+
+return lib.switch

--- a/imports/switch/shared.lua
+++ b/imports/switch/shared.lua
@@ -16,13 +16,14 @@
 local _cache = setmetatable({}, { __mode = "k" })
 local t_unpack = table.unpack
 
---- compile once per cases to a fast dispatcher (kept local; not exported)
+-- compile once per cases to a fast dispatcher (kept local; not exported)
 --- @param cases SwitchCases
---- @return fun(value:any, fallthrough:boolean|nil, ...:any):any
+--- @return fun(value:any|any[], fallthrough:boolean|nil, ...:any):any
 local function compile(cases)
     local map, preds, defaultIndex = {}, {}, nil
     local n = #cases
 
+    -- Pre-index: single values + list entries -> first matching index
     for i = 1, n do
         local m = cases[i].match
         local mt = type(m)
@@ -40,23 +41,53 @@ local function compile(cases)
         end
     end
 
+    -- Find earliest matching case index for a single value
+    local function resolveOne(v)
+        local i = map[v]
+        if i ~= nil then return i end
+        for k = 1, #preds do
+            local pi = preds[k]
+            if cases[pi].match(v) then return pi end
+        end
+        return nil
+    end
+
+    -- From a list of values, pick the earliest matching index among them
+    local function resolveFromList(list)
+        local best
+        -- exact/list map hits (O(1) each)
+        for vi = 1, #list do
+            local idx = map[list[vi]]
+            if idx and (not best or idx < best) then best = idx end
+        end
+        -- predicates only if no direct hit
+        if not best then
+            for k = 1, #preds do
+                local pi = preds[k]
+                local pred = cases[pi].match
+                for vi = 1, #list do
+                    if pred(list[vi]) then best = pi; break end
+                end
+                if best then break end
+            end
+        end
+        return best
+    end
+
     return function(value, fallthrough, ...)
         local stop, res
         local function breakFn() stop = true end
 
-        local i = map[value]
-        if i == nil then
-            for k = 1, #preds do
-                local pi = preds[k]
-                if cases[pi].match(value) then
-                    i = pi; break
-                end
-            end
-            if i == nil then i = defaultIndex end
+        local startIndex
+        if type(value) == "table" then
+            startIndex = resolveFromList(value) or defaultIndex
+        else
+            startIndex = resolveOne(value) or defaultIndex
         end
-        if i == nil then return nil end
+        if not startIndex then return nil end
 
         if fallthrough then
+            local i = startIndex
             while i <= n do
                 res = cases[i].action(breakFn, ...)
                 if stop then break end
@@ -64,47 +95,28 @@ local function compile(cases)
             end
             return res
         else
-            return cases[i].action(breakFn, ...)
+            return cases[startIndex].action(breakFn, ...)
         end
     end
 end
 
 --- Switch API (value first, cases third).
 --- Call as:
----   lib.switch(value, fallthrough, cases, ...)
----   lib.switch({ value, ... }, fallthrough, cases)
+---   lib.switch(value, fallthrough, cases, ...)       -- value is a single value
+---   lib.switch({v1, v2, ...}, true, cases, ...)      -- value is a list; picks earliest match; with fallthrough runs forward
 --- @generic R
---- @param valueOrArgs any|any[]          -- single value OR { value, arg1, arg2, ... }
+--- @param valueOrList any|any[]          -- single value OR list of values to test
 --- @param fallthrough boolean|nil         -- true = allow fallthrough; false/nil = stop at first
 --- @param cases SwitchCases
 --- @param ... any
 --- @return R|any
-function lib.switch(valueOrArgs, fallthrough, cases, ...)
+function lib.switch(valueOrList, fallthrough, cases, ...)
     local dispatch = _cache[cases]
     if not dispatch then
         dispatch = compile(cases)
         _cache[cases] = dispatch
     end
-
-    if type(valueOrArgs) == "table" then
-        local value = valueOrArgs[1]
-        local argc = #valueOrArgs
-        if argc > 1 then
-            local packed, p = {}, 0
-            for i = 2, argc do
-                p = p + 1; packed[p] = valueOrArgs[i]
-            end
-            local extra = { ... }
-            for i = 1, #extra do
-                p = p + 1; packed[p] = extra[i]
-            end
-            return dispatch(value, fallthrough, t_unpack(packed))
-        else
-            return dispatch(value, fallthrough, ...)
-        end
-    else
-        return dispatch(valueOrArgs, fallthrough, ...)
-    end
+    return dispatch(valueOrList, fallthrough, ...)
 end
 
 return lib.switch


### PR DESCRIPTION
## Description  
This PR introduces a new `lib.switch` utility function for Lua that provides a flexible, readable alternative to long `if/elseif` chains. The implementation supports value-based matching, lists of possible values, predicate functions, and a `"default"` fallback, with optional JavaScript-style fallthrough behavior.  

## Changes Made  
- Added `lib.switch(valueOrList, fallthrough, cases, ...)` API:  
  - **Value-first signature** for natural usage.  
  - First parameter can be a **single value** or a **list of values** to test.  
  - Arguments are always provided as variadic parameters (4th, 5th, 6th… positions).  
- Implemented `compile` step with weak-key caching to minimize recomputation.  
- Supported match types:  
  - Single values (`number`, `string`, etc.).  
  - Multi-value case matches (`{2,4,6}`).  
  - Predicate functions (`function(v) return v < 0 end`).  
  - `"default"` (fallback if no match found).  
- Supported behaviors:  
  - `fallthrough = true`: executes multiple cases sequentially until `breakFn()` is called.  
  - `fallthrough = false` (default): executes only the first matching case.  
  - Explicit `breakFn()` can halt fallthrough early.  
- Returned the result of the executed action (last case result in fallthrough mode).  

## Testing  
- Verified exact matches return correct result.  
- Verified lists of possible values (`{'foo','bar'}`) resolve to the earliest matching case.  
- Verified multi-value case matches (`{2,4,6}`) trigger correctly.  
- Verified predicate functions work as expected.  
- Verified `"default"` triggers when no matches exist.  
- Verified fallthrough behavior matches JavaScript semantics.  
- Verified variadic arguments (4th, 5th, etc.) are passed through correctly.  
- Verified `breakFn()` stops fallthrough early.  

## Performance Impact  
- Uses O(1) map lookups for single values and list entries.  
- Predicate checks only run when no value/list match exists.  
- Weak-key cache ensures compilation overhead happens once per cases table.  
- Efficient loop structure with minimal allocations.  

## Example Usages  

### Example 1 – Basic Value Match  
```lua
local cases = {
  { match = 2, action = function(_, n) return n .. " is two" end },
  { match = function(v) return v > 5 end, action = function(_, n) return n .. " is greater than 5" end },
  { match = "default", action = function(_, n) return n .. " didn't match anything else" end },
}
local result = lib.switch(2, false, cases, 2)
print(result) -- "2 is two"
```  

### Example 2 – Fallthrough with List of Values  
```lua
local cases = {
  { match = "concat",    action = function(_, a, b) print(a .. b) end },
  { match = "nonconcat", action = function(_, a, b) print(a) end },
  { match = "default",   action = function() print("no match") end },
}

lib.switch({"concat", "nonconcat"}, true, cases, "Hello ", "World")
-- Output:
-- Hello World
-- Hello
-- no match
```  

## Additional Notes  
- Initial implementation request for a structured switch-case utility in `ox_lib`.  
- Recommended to use the variadic form (`lib.switch(value, false, cases, ...)`) in hot code paths.  
- `"default"` case should be placed last for clarity.  

**EDIT:** Updated to reflect recent changes. The first argument, if a table, is now treated as a list of values to match.  
Arguments are no longer accepted inside that table and must always be passed as variadic parameters (4th, 5th, 6th…).
