### PR TITLE
fix(zones): set zone distance on creation

### DIFF
--- a/imports/zones/shared.lua
+++ b/imports/zones/shared.lua
@@ -341,6 +341,8 @@ end
 ---@return CZone
 local function setZone(data)
     ---@cast data CZone
+    local coords = cache.coords or GetEntityCoords(cache.ped)
+    data.distance = #(data.coords - coords)
     data.remove = removeZone
     data.contains = data.contains or contains
 


### PR DESCRIPTION
Possibly resolves a bug introduced by the grid changes when distance is erroneously passed to the zone creation data and referenced by other scripts.

NOTE: This particular micro-optimisation is no longer suitable as it will not update if the zone is outside your neighbouring cells. In the future, it would be better to calculate the distance when referenced using an __index metamethod (caching optional).