### PR TITLE
Feature: Added definable dataset for fivemanage logging

### DIFF
--- a/imports/logger/server.lua
+++ b/imports/logger/server.lua
@@ -94,6 +94,7 @@ end
 
 if service == 'fivemanage' then
     local key = GetConvar('fivemanage:key', '')
+    local dataset = GetConvar('fivemanage:dataset', 'default')
 
     if key ~= '' then
         local endpoint = 'https://api.fivemanage.com/api/logs/batch'
@@ -101,7 +102,8 @@ if service == 'fivemanage' then
         local headers = {
             ['Content-Type'] = 'application/json',
             ['Authorization'] = key,
-            ['User-Agent'] = 'ox_lib'
+            ['User-Agent'] = 'ox_lib',
+            ['X-Fivemanage-Dataset'] = dataset,
         }
 
         function lib.logger(source, event, message, ...)


### PR DESCRIPTION
This PR adds a simple convar that server owners can set to define the dataset they want to use when using ox_lib logger alongside fivemanage.

Details:
* Added convar: `fivemanage:dataset`
  * defaults to: `"default"`

According to the outcome of this PR, another will be made for updating the documentation relating to this change.