### PR TITLE
fix(table): restore expected behavior in table_matches

### DIFF
--- a/imports/table/shared.lua
+++ b/imports/table/shared.lua
@@ -47,9 +47,10 @@ end
 ---@return boolean
 ---Compares if two values are equal, iterating over tables and matching both keys and values.
 local function table_matches(t1, t2)
-    local tabletype1 = table.type(t1)
+	local type1, type2 = type(t1), type(t2)
 
-    if not tabletype1 then return t1 == t2 end
+	if type1 ~= type2 then return false end
+	if type1 ~= 'table' and type2 ~= 'table' then return t1 == t2 end
 
     if tabletype1 ~= table.type(t2) or (tabletype1 == 'array' and #t1 ~= #t2) then
         return false


### PR DESCRIPTION
- The refactor in [Commit 4c460e0](https://github.com/CommunityOx/ox_lib/commit/4c460e0bd9792f6d337378968c84cf85d4033052) introduced stricter type checks (using table.type and array length comparison), which caused empty tables and tables with nil values to be considered unequal. 
- This commit removes the strict shape checks and restores the original deep equality semantics, ensuring {} == {x=nil}.