### PR TITLE
fix(table_matches): remove leftover strict shape check from df7a6b9

### DIFF
--- a/imports/table/shared.lua
+++ b/imports/table/shared.lua
@@ -52,10 +52,6 @@ local function table_matches(t1, t2)
 	if type1 ~= type2 then return false end
 	if type1 ~= 'table' and type2 ~= 'table' then return t1 == t2 end
 
-    if tabletype1 ~= table.type(t2) or (tabletype1 == 'array' and #t1 ~= #t2) then
-        return false
-    end
-
     for k, v1 in pairs(t1) do
         local v2 = t2[k]
         if v2 == nil or not table_matches(v1, v2) then


### PR DESCRIPTION
- The previous fix (commit [df7a6b9](https://github.com/CommunityOx/ox_lib/commit/df7a6b9c21ffa1c9af63455b3feb405e8e8395b6)) mistakenly left in a table.type / #t1 == #t2 check that breaks equality for {} and {x=nil}.
- This removes that leftover check, restoring the intended deep equality semantics.