### PR TITLE
Fix: progressbar prop overload

### DIFF
--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -11,6 +11,7 @@ local DisableControlAction = DisableControlAction
 local DisablePlayerFiring = DisablePlayerFiring
 local playerState = LocalPlayer.state
 local createdProps = {}
+local maxProps = GetConvarInt('ox:progressPropLimit', 2)
 
 ---@class ProgressPropProps
 ---@field model string
@@ -90,7 +91,7 @@ local function startProgress(data)
     end
 
     if data.prop then
-        playerState:set('lib:progressProps', data.prop, true)
+        TriggerServerEvent('ox_lib:progressProps', data.prop)
     end
 
     local disable = data.disable
@@ -137,7 +138,7 @@ local function startProgress(data)
     end
 
     if data.prop then
-        playerState:set('lib:progressProps', nil, true)
+        TriggerServerEvent('ox_lib:progressProps', nil)
     end
 
     if anim then
@@ -258,7 +259,8 @@ AddStateBagChangeHandler('lib:progressProps', nil, function(bagName, key, value,
     if value.model then
         playerProps[#playerProps + 1] = createProp(ped, value)
     else
-        for i = 1, #value do
+        local propCount = math.min(maxProps, #value)
+        for i = 1, propCount do
             local prop = value[i]
 
             if prop then

--- a/resource/interface/server/progress.lua
+++ b/resource/interface/server/progress.lua
@@ -1,0 +1,12 @@
+local maxProps = GetConvarInt('ox:progressPropLimit', 2)
+
+---@param props ProgressPropProps | ProgressPropProps[] | nil  
+RegisterNetEvent('ox_lib:progressProps', function(props)
+    if type(props) == 'table' then
+        props = #props > maxProps and { table.unpack(props, 1, maxProps) } or props
+    else
+        props = nil
+    end
+
+    Player(source).state:set('lib:progressProps', props, true)
+end)


### PR DESCRIPTION
In regards to the issue #55 sharing an "exploit" allowing to crash or severely affect players performance wise in onesync range of the player, this PR adds in a extra layer of validation both server and client side to address it.

Initially only an extra validation would be made client side to limit the number of props, but in the case of servers using strict nui statebags I adapted it to send the request to the server to set the statebag while also limiting the number of props that can be attached to mitigate the attack.
Keeping the two checks on both contexts allows to protect against the issue by limiting the event being abused but also the statebag being set by a malicious client.

Documentation will be updated if this fix is considered to inclue the new convar that determines the maximum number of props attached to a player for the progressbar. The convar is named `lib:progressproplimit`, it's default value is `2` and it's replicate.