### PR TITLE
fix(progress): prop replication overload

### DIFF
--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -11,6 +11,7 @@ local DisableControlAction = DisableControlAction
 local DisablePlayerFiring = DisablePlayerFiring
 local playerState = LocalPlayer.state
 local createdProps = {}
+local maxProps = GetConvarInt('ox:progressPropLimit', 2)
 
 ---@class ProgressPropProps
 ---@field model string
@@ -34,13 +35,16 @@ local createdProps = {}
 ---@field disable? { move?: boolean, sprint?: boolean, car?: boolean, combat?: boolean, mouse?: boolean }
 
 local function createProp(ped, prop)
-    lib.requestModel(prop.model)
+    local ok, result = pcall(lib.requestModel, prop.model)
+
+    if not ok then return lib.print.error(result) end
+
     local coords = GetEntityCoords(ped)
-    local object = CreateObject(prop.model, coords.x, coords.y, coords.z, false, false, false)
+    local object = CreateObject(result, coords.x, coords.y, coords.z, false, false, false)
 
     AttachEntityToEntity(object, ped, GetPedBoneIndex(ped, prop.bone or 60309), prop.pos.x, prop.pos.y, prop.pos.z, prop.rot.x, prop.rot.y, prop.rot.z, true,
         true, false, true, prop.rotOrder or 0, true)
-    SetModelAsNoLongerNeeded(prop.model)
+    SetModelAsNoLongerNeeded(result)
 
     return object
 end
@@ -90,7 +94,7 @@ local function startProgress(data)
     end
 
     if data.prop then
-        playerState:set('lib:progressProps', data.prop, true)
+        TriggerServerEvent('ox_lib:progressProps', data.prop)
     end
 
     local disable = data.disable
@@ -137,7 +141,7 @@ local function startProgress(data)
     end
 
     if data.prop then
-        playerState:set('lib:progressProps', nil, true)
+        TriggerServerEvent('ox_lib:progressProps', nil)
     end
 
     if anim then
@@ -225,14 +229,18 @@ end
 
 local function deleteProgressProps(serverId)
     local playerProps = createdProps[serverId]
+
     if not playerProps then return end
+
+    createdProps[serverId] = nil
+
     for i = 1, #playerProps do
         local prop = playerProps[i]
+
         if DoesEntityExist(prop) then
             DeleteEntity(prop)
         end
     end
-    createdProps[serverId] = nil
 end
 
 RegisterNetEvent('onPlayerDropped', function(serverId)
@@ -248,22 +256,29 @@ AddStateBagChangeHandler('lib:progressProps', nil, function(bagName, key, value,
     local ped = GetPlayerPed(ply)
     local serverId = GetPlayerServerId(ply)
 
-    if not value then
+    if not value or createdProps[serverId] then
         return deleteProgressProps(serverId)
     end
 
-    createdProps[serverId] = {}
-    local playerProps = createdProps[serverId]
+    local playerProps = {}
 
     if value.model then
-        playerProps[#playerProps + 1] = createProp(ped, value)
+        local prop = createProp(ped, value)
+
+        if prop then
+            playerProps[#playerProps + 1] = createProp(ped, value)
+        end
     else
-        for i = 1, #value do
-            local prop = value[i]
+        local propCount = math.min(maxProps, #value)
+
+        for i = 1, propCount do
+            local prop = createProp(ped, value[i])
 
             if prop then
-                playerProps[#playerProps + 1] = createProp(ped, prop)
+                playerProps[#playerProps + 1] = prop
             end
         end
     end
+
+    createdProps[serverId] = playerProps
 end)

--- a/resource/interface/server/progress.lua
+++ b/resource/interface/server/progress.lua
@@ -1,0 +1,12 @@
+local maxProps = GetConvarInt('ox:progressPropLimit', 2)
+
+---@param props ProgressPropProps | ProgressPropProps[] | nil
+RegisterNetEvent('ox_lib:progressProps', function(props)
+    if type(props) == 'table' then
+        props = #props > maxProps and { table.unpack(props, 1, maxProps) } or props
+    else
+        props = nil
+    end
+
+    Player(source).state:set('lib:progressProps', props, true)
+end)


### PR DESCRIPTION
Resolves an exploit introduced by https://github.com/overextended/ox_lib/pull/515 (see https://github.com/CommunityOx/ox_lib/issues/55) that allows bad actors to replicate an excessive number of props and force players within sync range to crash. This is based on changes by @Maximus7474 but with some additional fixes/improvements.

- Limits the number of props that can be spawned using convar `ox:progressPropLimit`.
- Adds validation for requested models, ensuring playerProps are only stored when a valid entity is created.
- Invalid models will no longer error and stop execution of the statebag handler.
- Adds support for strict state bags.
- Disallows spawning additional props for players who already have attached props.

If you aren't already, you should be aiming to support `setr sv_stateBagStrictMode 1` in all your scripts to prevent unverified client-set values from being synced to all players.