### PR TITLE
Hotfix: progress props not despawning

### DIFF
--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -266,7 +266,7 @@ AddStateBagChangeHandler('lib:progressProps', nil, function(bagName, key, value,
         local prop = createProp(ped, value)
 
         if prop then
-            playerProps[#playerProps + 1] = createProp(ped, value)
+            playerProps[#playerProps + 1] = prop
         end
     else
         local propCount = math.min(maxProps, #value)


### PR DESCRIPTION
Within the [PR #58](https://github.com/CommunityOx/ox_lib/pull/58) addressing the exploit causing crashes when oversaturating the progressbar prop system, a slight oversight occured leading to double generation of the props leading to believe that the props weren't being deleted.

This addresses the minor oversight of @PotatoFarmer441 PR.