### PR TITLE
feat(interface/progress): support cancelprogress keybind in RedM

### DIFF
--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -58,6 +58,7 @@ local function interruptProgress(data)
 end
 
 local isFivem = cache.game == 'fivem'
+local isRedm = cache.game == 'redm'
 
 local controls = {
     INPUT_LOOK_LR = isFivem and 1 or 0xA987235F,
@@ -226,6 +227,19 @@ end)
 if isFivem then
     RegisterKeyMapping('cancelprogress', locale('cancel_progress'), 'keyboard', 'x')
 end
+
+if isRedM then
+    CreateThread(function()
+        while true do
+            Wait(100)
+            if lib.progressActive() and IsControlPressed(0, 0x8CC9CD42) then
+                ExecuteCommand('cancelprogress')
+                Wait(500)
+            end
+        end
+    end)
+end
+
 
 local function deleteProgressProps(serverId)
     local playerProps = createdProps[serverId]

--- a/resource/interface/client/progress.lua
+++ b/resource/interface/client/progress.lua
@@ -228,7 +228,7 @@ if isFivem then
     RegisterKeyMapping('cancelprogress', locale('cancel_progress'), 'keyboard', 'x')
 end
 
-if isRedM then
+if isRedm then
     CreateThread(function()
         while true do
             Wait(100)
@@ -239,7 +239,6 @@ if isRedM then
         end
     end)
 end
-
 
 local function deleteProgressProps(serverId)
     local playerProps = createdProps[serverId]


### PR DESCRIPTION
- Added a lightweight thread to detect X key manually in RedM, with a cooldown to prevent spam.