### PR TITLE
Fix: Skillcheck animation speed inconsistencies by switching to time-…

### DIFF
--- a/web/src/features/skillcheck/indicator.tsx
+++ b/web/src/features/skillcheck/indicator.tsx
@@ -63,13 +63,11 @@ const Indicator: React.FC<Props> = ({
     },
     [multiplier, handleComplete]
   );
-
   const keyHandler = useCallback(
     (e: KeyboardEvent) => {
       const capitalHetaCode = 880;
       const isNonLatin = e.key.charCodeAt(0) >= capitalHetaCode;
       var convKey = e.key.toLowerCase()
-
       if (isNonLatin) {
         if (e.code.indexOf('Key') === 0 && e.code.length === 4) { // i.e. 'KeyW'
           convKey = e.code.charAt(3);
@@ -79,12 +77,11 @@ const Indicator: React.FC<Props> = ({
           convKey = e.code.charAt(5);
         }
       }
-
       setKeyPressed(convKey.toLowerCase());
     },
     [skillCheck]
   );
-  
+
   useEffect(() => {
     setIndicatorAngle(-90);
     startTimeRef.current = null;
@@ -110,11 +107,9 @@ const Indicator: React.FC<Props> = ({
     window.removeEventListener('keydown', keyHandler);
     completedRef.current = true;
 
-    if (keyPressed !== skillCheck.key || indicatorAngle < angle || indicatorAngle > angle + offset) {
+    if (keyPressed !== skillCheck.key || indicatorAngle < angle || indicatorAngle > angle + offset)
       handleComplete(false);
-    } else {
-      handleComplete(true);
-    }
+    else handleComplete(true);
 
     setKeyPressed(false);
   }, [


### PR DESCRIPTION
…based RAF loop

This PR fixes long-standing issues with the skillcheck mini-game animation speed being inconsistent across machines and after long play sessions. Some players reported extremely slow indicator movement, others extremely fast, and many noticed that the speed changed unpredictably the longer they stayed logged in.

The root cause was that the skillcheck relied on a useInterval tick (setInterval-like behavior) and assumed it fired every 1ms. In reality, browser timer clamping and throttling make interval timing highly unpredictable — especially in embedded CEF browsers like FiveM’s NUI.

This PR replaces tick-based animation with a time-based requestAnimationFrame loop using performance.now(), ensuring perfectly consistent animation timing across all hardware and browser states. I have used this method in other NUI based skillcheck scripts to address this same behavior.

I have tested this with the pre-defined difficult settings for skillcheck, easy, medium, and hard along with the tabled based settings. The speeds seem consistent with the old behavior when using this new method. User experience should be consistent with this updated code.