### PR TITLE
feat(imports/logger): support metadata table for Fivemanage logger

### DIFF
--- a/imports/logger/server.lua
+++ b/imports/logger/server.lua
@@ -128,17 +128,43 @@ if service == 'fivemanage' then
                 end)
             end
 
+            local metadata = {
+                hostname = hostname,
+                service = event,
+                source = source,
+            }
+
+            local playerTags = formatTags(source, nil)
+            if playerTags and type(playerTags) == 'string' then
+                local tempTable = { string.strsplit(',', playerTags) }
+                for _, v in pairs(tempTable) do
+                    local key, value = string.strsplit(':', v)
+                    if key and value then
+                        metadata[key] = value
+                    end
+                end
+            end
+
+            local args = { ... }
+            for _, arg in pairs(args) do
+                if type(arg) == 'table' then
+                    for k, v in pairs(arg) do
+                        metadata[k] = v
+                    end
+                elseif type(arg) == 'string' then
+                    local key, value = string.strsplit(':', arg)
+                    if key and value then
+                        metadata[key] = value
+                    end
+                end
+            end
+
             bufferSize += 1
             buffer[bufferSize] = {
                 level = "info",
                 message = message,
                 resource = cache.resource,
-                metadata = {
-                    hostname = hostname,
-                    service = event,
-                    source = source,
-                    tags = formatTags(source, ... and string.strjoin(',', string.tostringall(...)) or nil),
-                }
+                metadata = metadata,
             }
         end
     end


### PR DESCRIPTION
Adds support for a table as the last argument, instead of a "key:value" spread argument. Backwards compatibility for both a table or/and a "key:value" arguments. Both params are converted to a proper field for Fivemanage, to prevent a "tags" field with comma separated values. 

Currently only added for Fivemanage. The Loki option does something similar, so should be fine. Not sure about Datadog, so I'll leave that be.

```lua
lib.logger(1, "command", "just some testing hehe", {
  playerSource = 1,
  customData = "Additional info"
})
```

```lua
lib.logger(1, "command", "just some testing hehe", "playerSource:1", "customData:Additional info")
```