### PR TITLE
fix(addKeybind): handle MOUSE_WHEEL as a momentary trigger

### DIFF
--- a/imports/addKeybind/client.lua
+++ b/imports/addKeybind/client.lua
@@ -66,6 +66,11 @@ function lib.addKeybind(data)
         if data.disabled or IsPauseMenuActive() then return end
         data.isPressed = true
         if data.onPressed then data:onPressed() end
+
+        if data.defaultMapper == 'MOUSE_WHEEL' then
+            data.isPressed = false
+            if data.onReleased then data:onReleased() end
+        end
     end)
 
     RegisterCommand('-' .. data.name, function()

--- a/package/client/resource/addKeybind/index.ts
+++ b/package/client/resource/addKeybind/index.ts
@@ -79,6 +79,11 @@ export function addKeybind(data: KeybindProps): CKeybind {
     if (kb.disabled || IsPauseMenuActive()) return;
     kb.isPressed = true;
     kb.onPressed?.call(kb);
+
+    if (kb.defaultMapper === "MOUSE_WHEEL") {
+      kb.isPressed = false;
+      kb.onReleased?.call(kb);
+    }
   }, false);
 
   RegisterCommand("-" + kb.name, () => {


### PR DESCRIPTION
This PR fixes issue #21 by handling MOUSE_WHEEL as a momentary trigger. Since the engine doesn't fire a release (-command) for scroll events, the keybind would stay 'stuck' in a pressed state. This change resets isPressed and calls onReleased immediately for scroll inputs.