### PR TITLE
fix(interface/menu): incosistent menu function types

### DIFF
--- a/resource/interface/client/menu.lua
+++ b/resource/interface/client/menu.lua
@@ -13,6 +13,7 @@ local openMenu
 
 ---@alias MenuPosition 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
 ---@alias MenuChangeFunction fun(selected: number, scrollIndex?: number, args?: any, checked?: boolean)
+---@alias MenuScrollSelectChangeFunction fun(selected: number, scrollIndex?: number, args?: any)
 
 ---@class MenuOptions
 ---@field label string
@@ -35,9 +36,9 @@ local openMenu
 ---@field disableInput? boolean
 ---@field canClose? boolean
 ---@field onClose? fun(keyPressed?: 'Escape' | 'Backspace')
----@field onSelected? MenuChangeFunction
----@field onSideScroll? MenuChangeFunction
----@field onCheck? MenuChangeFunction
+---@field onSelected? MenuScrollSelectChangeFunction
+---@field onSideScroll? MenuScrollSelectChangeFunction
+---@field onCheck? fun(selected: number, checked: boolean, args?: any)
 ---@field cb? MenuChangeFunction
 
 ---@param data MenuProps


### PR DESCRIPTION
Using the MenuChangeFunction for everything was incosistent as they have different args for the event functions of the menu and it provided especially wrong types with the checked function.