### PR TITLE
Add lockState support to vehicle properties

### DIFF
--- a/resource/vehicleProperties/client.lua
+++ b/resource/vehicleProperties/client.lua
@@ -12,6 +12,7 @@ if cache.game == 'redm' then return end
 ---@field model? number
 ---@field plate? string
 ---@field plateIndex? number
+---@field lockState? number
 ---@field bodyHealth? number
 ---@field engineHealth? number
 ---@field tankHealth? number
@@ -202,6 +203,7 @@ function lib.getVehicleProperties(vehicle)
             model = GetEntityModel(vehicle),
             plate = GetVehicleNumberPlateText(vehicle),
             plateIndex = GetVehicleNumberPlateTextIndex(vehicle),
+            lockState = GetVehicleDoorLockStatus(vehicle),
             bodyHealth = math.floor(GetVehicleBodyHealth(vehicle) + 0.5),
             engineHealth = math.floor(GetVehicleEngineHealth(vehicle) + 0.5),
             tankHealth = math.floor(GetVehiclePetrolTankHealth(vehicle) + 0.5),
@@ -320,6 +322,10 @@ function lib.setVehicleProperties(vehicle, props, fixVehicle)
 
     if props.plateIndex then
         SetVehicleNumberPlateTextIndex(vehicle, props.plateIndex)
+    end
+
+    if props.lockState ~= nil then
+        SetVehicleDoorLockStatus(vehicle, props.lockState)
     end
 
     if props.bodyHealth then


### PR DESCRIPTION
Hello,

I’d like to propose a small improvement to vehicle properties handling.

This change adds support for the vehicle door lock state (lockState) by:
- Including lockState in the VehicleProperties type
- Reading the value using GetVehicleDoorLockStatus in getVehicleProperties
- Applying the value using SetVehicleDoorLockStatus in setVehicleProperties

This allows vehicle lock status to be properly saved and restored alongside other vehicle properties.

Let me know if this fits the project direction or if any adjustments are needed. Thank you!