### PR TITLE
Fix: handle null value in JS callback from package

### DIFF
--- a/package/client/resource/callback/index.ts
+++ b/package/client/resource/callback/index.ts
@@ -47,7 +47,7 @@ export function triggerServerCallback<T = unknown>(
 
   return new Promise<T>((resolve, reject) => {
     pendingCallbacks[key] = (args) => {
-      if (args[0] === 'cb_invalid') reject(`callback '${eventName} does not exist`);
+      if (Array.isArray(args) && args[0] === 'cb_invalid') reject(`callback '${eventName} does not exist`);
 
       resolve(args);
     };

--- a/package/server/resource/callback/index.ts
+++ b/package/server/resource/callback/index.ts
@@ -29,7 +29,7 @@ export function triggerClientCallback<T = unknown>(
 
   return new Promise<T>((resolve, reject) => {
     pendingCallbacks[key] = (args) => {
-      if (args[0] === 'cb_invalid') reject(`callback '${eventName} does not exist`);
+      if (Array.isArray(args) && args[0] === 'cb_invalid') reject(`callback '${eventName} does not exist`);
 
       resolve(args);
     };


### PR DESCRIPTION
Issue that is encountered is that in the situations where a callback returns a null value it fails within the npm package of ox_lib.
This isn't the case with the lua callbacks because of the difference in serialization of the lua and js SCRT in fivem if I'm not mistaken.