### PR TITLE
fix(client): close active NUI elements before opening new ones

### DIFF
--- a/resource/interface/client/alert.lua
+++ b/resource/interface/client/alert.lua
@@ -23,6 +23,7 @@ local alertId = 0
 ---@param timeout? number Force the window to timeout after `x` milliseconds.
 ---@return 'cancel' | 'confirm' | nil
 function lib.alertDialog(data, timeout)
+    lib.closeAllNui('alert')
     if alert then return end
 
     local id = alertId + 1

--- a/resource/interface/client/context.lua
+++ b/resource/interface/client/context.lua
@@ -54,6 +54,7 @@ end
 
 ---@param id string
 function lib.showContext(id)
+    lib.closeAllNui('context')
     if not contextMenus[id] then error('No context menu of such id found.') end
 
     local data = contextMenus[id]

--- a/resource/interface/client/input.lua
+++ b/resource/interface/client/input.lua
@@ -42,6 +42,7 @@ local input
 ---@param options InputDialogOptionsProps[]?
 ---@return string[] | number[] | boolean[] | nil
 function lib.inputDialog(heading, rows, options)
+    lib.closeAllNui('input')
     if input then return end
     input = promise.new()
 

--- a/resource/interface/client/main.lua
+++ b/resource/interface/client/main.lua
@@ -20,3 +20,21 @@ function lib.resetNuiFocus()
     SetNuiFocus(false, false)
     SetNuiFocusKeepInput(keepInput)
 end
+
+function lib.closeAllNui(except)
+    if except ~= 'context' and lib.getOpenContextMenu() then
+        lib.hideContext(false)
+    end
+    if except ~= 'menu' and lib.getOpenMenu() then
+        lib.hideMenu(false)
+    end
+    if except ~= 'input' then
+        lib.closeInputDialog()
+    end
+    if except ~= 'alert' then
+        lib.closeAlertDialog()
+    end
+    if except ~= 'radial' then
+        lib.hideRadial()
+    end
+end

--- a/resource/interface/client/menu.lua
+++ b/resource/interface/client/menu.lua
@@ -54,6 +54,7 @@ end
 ---@param id string
 ---@param startIndex? number
 function lib.showMenu(id, startIndex)
+    lib.closeAllNui('menu')
     local menu = registeredMenus[id]
     if not menu then
         error(('No menu with id %s was found'):format(id))


### PR DESCRIPTION
## Summary

- Fixes NUI focus bugs when multiple ox_lib UI elements overlap (e.g., opening an `inputDialog` while a context menu is open)
- Root cause: `keepInput` in `main.lua` is a single variable that gets overwritten when a second UI opens, losing the original pre-NUI state
- Adds `lib.closeAllNui(except)` that cleanly closes all other open NUI elements before a new one opens

## Changes

- **main.lua**: Added `lib.closeAllNui(except)` — closes context, menu, input, alert, and radial (with guards to avoid unnecessary `resetNuiFocus` calls)
- **context.lua**: `lib.showContext()` calls `lib.closeAllNui('context')` before opening
- **input.lua**: `lib.inputDialog()` calls `lib.closeAllNui('input')` before opening
- **alert.lua**: `lib.alertDialog()` calls `lib.closeAllNui('alert')` before opening
- **menu.lua**: `lib.showMenu()` calls `lib.closeAllNui('menu')` before opening

The `except` parameter ensures a UI type doesn't close itself (e.g., navigating between context sub-menus still works normally).

## Test plan

- [ ] Open a context menu, then trigger an `inputDialog` via script — context should close, input should open cleanly
- [ ] Navigate context sub-menus — should work normally (`except='context'`)
- [ ] Open an input dialog, then trigger an alert — input should close (resolves `nil`), alert should open
- [ ] Open a menu, then trigger a context menu — menu should close, context should open
- [ ] Close any UI normally (no other UI open) — should work exactly as before