### PR TITLE
fix(cron): fix scheduling bugs and add destroy method

### DIFF
--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -356,6 +356,11 @@ function OxTask:stop(msg, internal)
     end
 end
 
+function OxTask:destroy()
+    self:stop()
+    tasks[self.id] = nil
+end
+
 ---@param expression string A cron expression such as `* * * * *` representing minute, hour, day, month, and day of the week.
 ---@param job fun(task: OxTask, date: osdate)
 ---@param options? { debug?: boolean }
@@ -390,8 +395,7 @@ end
 
 -- reschedule any dead tasks on a new day
 lib.cron.new('0 0 * * *', function()
-    for i = 1, #tasks do
-        local task = tasks[i]
+    for _, task in pairs(tasks) do
         if not task.isActive and not task.manualStop then
             task:run()
         end

--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -276,6 +276,7 @@ end
 
 ---@type OxTask[]
 local tasks = {}
+local nextTaskId = 0
 
 function OxTask:scheduleTask()
     local runAt = self:getNextTime()
@@ -383,7 +384,8 @@ function lib.cron.new(expression, job, options)
     task.day = parseCron(day, 'day')
     task.month = parseCron(month, 'month')
     task.weekday = parseCron(weekday, 'wday')
-    task.id = #tasks + 1
+    nextTaskId = nextTaskId + 1
+    task.id = nextTaskId
     task.job = job
     task.lastRun = nil
     task.maxDelay = task.maxDelay or 1

--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -281,7 +281,7 @@ function OxTask:scheduleTask()
     local runAt = self:getNextTime()
 
     if not runAt then
-        return self:stop('getNextTime returned no value')
+        return self:stop('getNextTime returned no value', true)
     end
 
     local currentTime = os.time()
@@ -289,7 +289,7 @@ function OxTask:scheduleTask()
 
     if sleep < 0 then
         if not self.maxDelay or -sleep > self.maxDelay then
-            return self:stop(self.debug and ('scheduled time expired %s seconds ago'):format(-sleep))
+            return self:stop(self.debug and ('scheduled time expired %s seconds ago'):format(-sleep), true)
         end
 
         if self.debug then
@@ -336,14 +336,16 @@ function OxTask:run()
     if self.isActive then return end
 
     self.isActive = true
+    self.manualStop = false
 
     CreateThread(function()
         while self:scheduleTask() do end
     end)
 end
 
-function OxTask:stop(msg)
+function OxTask:stop(msg, internal)
     self.isActive = false
+    self.manualStop = not internal
 
     if self.debug then
         if msg then
@@ -390,7 +392,7 @@ end
 lib.cron.new('0 0 * * *', function()
     for i = 1, #tasks do
         local task = tasks[i]
-        if not task.isActive then
+        if not task.isActive and not task.manualStop then
             task:run()
         end
     end

--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -99,8 +99,8 @@ local function parseCron(value, unit)
     if not value or value == '*' then return end
 
     if unit == 'day' and value:lower() == 'l' then
-        return function()
-            return getMaxDaysInMonth(currentDate.month, currentDate.year)
+        return function(month, year)
+            return getMaxDaysInMonth(month or currentDate.month, year or currentDate.year)
         end
     end
 
@@ -245,64 +245,105 @@ local function getTimeUnit(value, unit)
     return value < currentTime and value + unitMax or value --[[@as number]]
 end
 
+---Checks if a given value matches a cron field specification.
+---@param field number|string|function|nil
+---@param value number
+---@param candidateMonth? number
+---@param candidateYear? number
+---@return boolean
+local function matchesField(field, value, candidateMonth, candidateYear)
+    if not field then return true end
+
+    if type(field) == 'function' then
+        return value == field(candidateMonth, candidateYear)
+    end
+
+    if type(field) == 'number' then
+        return value == field
+    end
+
+    local step = field:match('^%*/(%d+)$')
+    if step then
+        return value % tonumber(step) == 0
+    end
+
+    local min, max = field:match('^(%d+)-(%d+)$')
+    if min and max then
+        min, max = tonumber(min), tonumber(max)
+        if max >= min then
+            return value >= min and value <= max
+        else
+            return value >= min or value <= max
+        end
+    end
+
+    for item in field:gmatch('%d+') do
+        if value == tonumber(item) then
+            return true
+        end
+    end
+
+    return false
+end
+
 ---@return number?
 function OxTask:getNextTime()
     if not self.isActive then return end
 
-    local day = getTimeUnit(self.day, 'day')
+    local now = os.time()
+    local startDate = os.date('*t', now) --[[@as Date]]
+    startDate.sec = 0
+    startDate.min = startDate.min + 1
+    startDate = os.date('*t', os.time(startDate)) --[[@as Date]]
 
-    if day == 0 then
-        day = getMaxDaysInMonth(currentDate.month)
-    end
+    for dayOffset = 0, 366 do
+        local candidate
 
-    if day ~= currentDate.day then return end
-
-    local month = getTimeUnit(self.month, 'month')
-    if month ~= currentDate.month then return end
-
-    local weekday = getTimeUnit(self.weekday, 'wday')
-    if weekday and weekday ~= currentDate.wday then return end
-
-    local minute = getTimeUnit(self.minute, 'min')
-    if not minute then return end
-
-    local hour = getTimeUnit(self.hour, 'hour')
-    if not hour then return end
-
-    if minute >= maxUnits.min then
-        if not self.hour then
-            hour += math.floor(minute / maxUnits.min)
+        if dayOffset == 0 then
+            candidate = startDate
+        else
+            local t = os.time({ year = startDate.year, month = startDate.month, day = startDate.day, hour = 12 }) + dayOffset * 86400
+            candidate = os.date('*t', t) --[[@as Date]]
         end
-        minute = minute % maxUnits.min
-    end
 
-    if hour >= maxUnits.hour and day then
-        if not self.day then
-            day += math.floor(hour / maxUnits.hour)
+        if matchesField(self.month, candidate.month)
+            and matchesField(self.day, candidate.day, candidate.month, candidate.year)
+            and matchesField(self.weekday, candidate.wday)
+        then
+            local startHour = (dayOffset == 0) and startDate.hour or 0
+
+            for h = startHour, 23 do
+                if matchesField(self.hour, h) then
+                    local startMin = (dayOffset == 0 and h == startDate.hour) and startDate.min or 0
+
+                    for m = startMin, 59 do
+                        if matchesField(self.minute, m) then
+                            local nextTime = os.time({
+                                year = candidate.year,
+                                month = candidate.month,
+                                day = candidate.day,
+                                hour = h,
+                                min = m,
+                                sec = 0,
+                            })
+
+                            if self.lastRun and nextTime - self.lastRun < 60 then
+                                if self.debug then
+                                    lib.print.debug(('Preventing duplicate execution of task %s - Last run: %s, Next scheduled: %s'):format(
+                                        self.id,
+                                        os.date('%c', self.lastRun),
+                                        os.date('%c', nextTime)
+                                    ))
+                                end
+                            else
+                                return nextTime
+                            end
+                        end
+                    end
+                end
+            end
         end
-        hour = hour % maxUnits.hour
     end
-
-    local nextTime = os.time({
-        min = minute,
-        hour = hour,
-        day = day or currentDate.day,
-        month = month or currentDate.month,
-        year = currentDate.year,
-    })
-
-    if self.lastRun and nextTime - self.lastRun < 60 then
-        if self.debug then
-            lib.print.debug(('Preventing duplicate execution of task %s - Last run: %s, Next scheduled: %s'):format(
-                self.id,
-                os.date('%c', self.lastRun),
-                os.date('%c', nextTime)
-            ))
-        end
-        return
-    end
-
-    return nextTime
 end
 
 ---@return number

--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -51,13 +51,6 @@ local validRanges = {
     wday = { min = 0, max = 7 },
 }
 
-local maxUnits = {
-    min = 60,
-    hour = 24,
-    wday = 7,
-    day = 31,
-    month = 12,
-}
 
 local weekdayMap = {
     sun = 1,
@@ -170,80 +163,6 @@ local function parseCron(value, unit)
     error(("^1invalid cron expression. '%s' is not supported for %s^0"):format(value, unit), 3)
 end
 
----@param value string|number|function|nil
----@param unit string
----@return number|false|nil
-local function getTimeUnit(value, unit)
-    local currentTime = currentDate[unit]
-
-    if not value then
-        return unit == 'min' and currentTime + 1 or currentTime
-    end
-
-    if type(value) == 'function' then
-        return value()
-    end
-
-    local unitMax = maxUnits[unit]
-
-    if type(value) == 'string' then
-        local stepValue = string.match(value, '*/(%d+)')
-
-        if stepValue then
-            local step = tonumber(stepValue)
-            for i = currentTime + 1, unitMax do
-                if i % step == 0 then return i end
-            end
-            return step + unitMax
-        end
-
-        local range = string.match(value, '%d+-%d+')
-        if range then
-            local min, max = string.strsplit('-', range)
-            min, max = tonumber(min, 10), tonumber(max, 10)
-
-            if unit == 'min' then
-                if currentTime >= max then
-                    return min + unitMax
-                end
-            elseif currentTime > max then
-                return min + unitMax
-            end
-
-            return currentTime < min and min or currentTime
-        end
-
-        local list = string.match(value, '%d+,%d+')
-        if list then
-            local values = {}
-            for listValue in string.gmatch(value, '%d+') do
-                values[#values + 1] = tonumber(listValue)
-            end
-            table.sort(values)
-
-            for i = 1, #values do
-                local listValue = values[i]
-                if unit == 'min' then
-                    if currentTime < listValue then
-                        return listValue
-                    end
-                elseif currentTime <= listValue then
-                    return listValue
-                end
-            end
-
-            return values[1] + unitMax
-        end
-
-        return false
-    end
-
-    if unit == 'min' then
-        return value <= currentTime and value + unitMax or value --[[@as number]]
-    end
-
-    return value < currentTime and value + unitMax or value --[[@as number]]
-end
 
 ---Checks if a given value matches a cron field specification.
 ---@param field number|string|function|nil
@@ -348,41 +267,7 @@ end
 
 ---@return number
 function OxTask:getAbsoluteNextTime()
-    local minute = getTimeUnit(self.minute, 'min')
-    local hour = getTimeUnit(self.hour, 'hour')
-    local day = getTimeUnit(self.day, 'day')
-    local month = getTimeUnit(self.month, 'month')
-    local year = getTimeUnit(self.year, 'year')
-
-    if self.day then
-        if currentDate.hour < hour or (currentDate.hour == hour and currentDate.min < minute) then
-            day = day - 1
-            if day < 1 then
-                day = getMaxDaysInMonth(currentDate.month)
-            end
-        end
-
-        if currentDate.hour > hour or (currentDate.hour == hour and currentDate.min >= minute) then
-            day = day + 1
-            if day > getMaxDaysInMonth(currentDate.month) or day == 1 then
-                day = 1
-                month = month + 1
-            end
-        end
-    end
-
-    ---@diagnostic disable-next-line: assign-type-mismatch
-    if os.time({ year = year, month = month, day = day, hour = hour, min = minute }) < os.time() then
-        year = year and year + 1 or currentDate.year + 1
-    end
-
-    return os.time({
-        min = minute < 60 and minute or 0,
-        hour = hour < 24 and hour or 0,
-        day = day or currentDate.day,
-        month = month or currentDate.month,
-        year = year or currentDate.year,
-    })
+    return self:getNextTime() or os.time()
 end
 
 function OxTask:getTimeAsString(timestamp)

--- a/imports/cron/server.lua
+++ b/imports/cron/server.lua
@@ -73,7 +73,7 @@ local monthMap = {
 ---@param year? number
 ---@return number
 local function getMaxDaysInMonth(month, year)
-    return os.date('*t', os.time({ year = year or currentDate.year, month = month + 1, day = -1 })).day --[[@as number]]
+    return os.date('*t', os.time({ year = year or currentDate.year, month = month + 1, day = 0 })).day --[[@as number]]
 end
 
 ---@param value string|number


### PR DESCRIPTION
### Fixes
- **getMaxDaysInMonth:** Fixed off-by-one error by using `day=0`. Previously returned 30 for January, 27 for February, etc.
- **getNextTime logic:** Rewritten to scan forward for the next execution time. This fixes:
1. Hour ranges (e.g., `0 17-23 * * *`) firing only once and stopping (Issue: #77).
2. Future-dated crons (e.g., `0 0 01 01 *`) failing to schedule if the target date is not today (Issue: #95).

### Improvements
- **task:destroy():** New method to stop tasks and remove them from the registry, ensuring they can be garbage collected.
- **Task ID management:** Switched to an incrementing counter instead of `#tasks+1` to prevent ID collisions when tasks are destroyed.
- **manualStop flag:** Prevents the midnight reschedule job from restarting tasks that were intentionally stopped by the user.
- **Code Cleanup:** Removed ~70 lines of redundant code in `getAbsoluteNextTime` by delegating logic to the updated `getNextTime`.

<details>
<summary>Test Code</summary>

```lua
-- Test 1: Hour range - uses current hour so minute overflow always triggers the bug
-- OLD: returns current hour's :00 (already past), task stops
-- NEW: returns next hour's :00 within the range
local currentHour = tonumber(os.date('%H'))
local rangeEnd = math.min(currentHour + 2, 23)
local hourExpr = ('0 %d-%d * * *'):format(currentHour, rangeEnd)
local t1 = lib.cron.new(hourExpr, function() end, { debug = true })
local next1 = t1:getNextTime()
print(('[Test 1 - Hour Range] expression: %s | isActive: %s | nextTime: %s'):format(
    hourExpr,
    tostring(t1.isActive),
    next1 and os.date('%c', next1) or 'nil'
))
t1:stop()

-- Test 2: Future day - schedules for tomorrow
-- OLD: returns nil because day != today
-- NEW: returns tomorrow's date
local tomorrow = os.date('*t', os.time() + 86400)
local expr = ('0 0 %d %d *'):format(tomorrow.day, tomorrow.month)
local t2 = lib.cron.new(expr, function() end, { debug = true })
local next2 = t2:getNextTime()
print(('[Test 2 - Future Day] expression: %s | isActive: %s | nextTime: %s'):format(
    expr,
    tostring(t2.isActive),
    next2 and os.date('%c', next2) or 'nil'
))
t2:stop()

-- Test 3: getMaxDaysInMonth - verifies day=0 fix
-- day=-1 returns second-to-last day, day=0 returns correct last day
local jan_old = os.date('*t', os.time({ year = 2026, month = 2, day = -1 })).day
local feb_old = os.date('*t', os.time({ year = 2026, month = 3, day = -1 })).day
local apr_old = os.date('*t', os.time({ year = 2026, month = 5, day = -1 })).day
local jan_new = os.date('*t', os.time({ year = 2026, month = 2, day = 0 })).day
local feb_new = os.date('*t', os.time({ year = 2026, month = 3, day = 0 })).day
local apr_new = os.date('*t', os.time({ year = 2026, month = 5, day = 0 })).day
print(('[Test 3 - Max Days] day=-1: Jan=%d Feb=%d Apr=%d | day=0: Jan=%d Feb=%d Apr=%d'):format(
    jan_old, feb_old, apr_old, jan_new, feb_new, apr_new
))

-- Test 4: Last day of month via L expression
-- OLD: nil (day != today + off-by-one)
-- NEW: correct last day of current month
local tL = lib.cron.new('0 0 L * *', function() end, { debug = true })
local nextL = tL:getNextTime()
print(('[Test 4 - Last Day (L)] nextTime: %s'):format(
    nextL and os.date('%c', nextL) or 'nil'
))
tL:stop()

-- Test 5: Task ID uniqueness after destroy
-- OLD: destroy() does not exist
-- NEW: IDs never collide after destroy
if t1.destroy then
    local t3 = lib.cron.new('0 0 * * *', function() end)
    local t4 = lib.cron.new('0 0 * * *', function() end)
    local id3, id4 = t3.id, t4.id
    t3:destroy()
    local t5 = lib.cron.new('0 0 * * *', function() end)
    print(('[Test 5 - Task ID] id3=%d id4=%d id5=%d | no_collision=%s'):format(
        id3, id4, t5.id,
        tostring(t5.id ~= id3 and t5.id ~= id4)
    ))
    t5:destroy()
    t4:destroy()
else
    print('[Test 5 - Task ID] skipped (destroy not available)')
end

-- Test 6: Manual stop flag
-- OLD: manualStop does not exist
-- NEW: manualStop=true when user calls stop()
local t6 = lib.cron.new('0 0 * * *', function() end)
t6:stop()
if t6.manualStop ~= nil then
    print(('[Test 6 - Manual Stop] manualStop: %s'):format(tostring(t6.manualStop)))
    if t6.destroy then t6:destroy() end
else
    print('[Test 6 - Manual Stop] skipped (manualStop not available)')
end
```

</details>

**Old code:**
```
[Test 1 - Hour Range]  expression: 0 13-15 * * * | nextTime: Mon Apr  6 13:00:00 2026  (past time, task dies)
[Test 2 - Future Day]  expression: 0 0 7 4 *    | nextTime: nil
[Test 3 - Max Days]    day=-1: Jan=30 Feb=27 Apr=29 | day=0: Jan=31 Feb=28 Apr=30
[Test 4 - Last Day (L)]                             | nextTime: nil
[Test 5 - Task ID]     skipped (destroy not available)
[Test 6 - Manual Stop] skipped (manualStop not available)
```

**New code:**
```
[Test 1 - Hour Range]  expression: 0 14-16 * * * | nextTime: Mon Apr  6 15:00:00 2026
[Test 2 - Future Day]  expression: 0 0 7 4 *    | nextTime: Tue Apr  7 00:00:00 2026
[Test 3 - Max Days]    day=-1: Jan=30 Feb=27 Apr=29 | day=0: Jan=31 Feb=28 Apr=30
[Test 4 - Last Day (L)]                             | nextTime: Thu Apr 30 00:00:00 2026
[Test 5 - Task ID]     id3=5 id4=6 id5=7 | no_collision=true
[Test 6 - Manual Stop] manualStop: true
```